### PR TITLE
remove empty authors line from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,7 +3,6 @@ changelog:
     labels:
       - ignore-for-release
       - dependencies
-    authors:
 
   categories:
     - title: Breaking Changes 🛠


### PR DESCRIPTION
this release yaml was invalid

## What does this change?

<!-- Add a description of what your PR changes here -->
I have removed the empty line of authors because it is invalid to have properties with no values in this yaml

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [x] Yes

<!--Please reference the ticket you are addressing -->

Issue number: Towards #2 

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
