### PR TITLE
Adds workflow file to check for labels on PRs

### DIFF
--- a/.github/workflows/check-pr-label.yml
+++ b/.github/workflows/check-pr-label.yml
@@ -1,0 +1,18 @@
+name: 
+
+on: [pull-request]
+
+jobs:
+  check-for-label:
+    runs-on: ubuntu-latest    
+    steps:
+    - name: Labels not added
+      if: >
+        contains(github.event.pull_request.labels.*.name, 'Breaking-Changes') == false &&
+        contains(github.event.pull_request.labels.*.name, 'Bug-Fixes') == false &&
+        contains(github.event.pull_request.labels.*.name, 'Documentation') == false &&
+        contains(github.event.pull_request.labels.*.name, 'Feature') == false &&
+        contains(github.event.pull_request.labels.*.name, 'Chore') == false
+      run: |
+        echo "This PR can't be merged, because it does not have a release category label. See release_notes.md"
+        exit 1

--- a/.github/workflows/check-pr-label.yml
+++ b/.github/workflows/check-pr-label.yml
@@ -1,6 +1,6 @@
 name: 
 
-on: [pull-request]
+on: [pull_request]
 
 jobs:
   check-for-label:


### PR DESCRIPTION
## What does this change?

This PR adds a file (check-pr-label.yml) that creates a workflow for checking for release category labels. 

### Common Theme?

This PR doesn't change Common itself, but it adds a workflow that blocks PRs to common-theme if they do have have one of the release category labels outlined in releases.yml

- [ ] Yes

<!--Please reference the ticket you are addressing -->

Issue number: /common-theme/9

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works

## Who needs to know about this?

@reshamas @SallyMcGrath @illicitonion 
